### PR TITLE
Feature/19 spring cloud config setting

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -40,4 +40,7 @@ object Dependencies {
     const val GRPC_TESTING = "io.grpc:grpc-testing:${DependencyVersion.GRPC}"
     const val GRPC_SERVER_SPRING = "net.devh:grpc-server-spring-boot-starter:${DependencyVersion.GRPC_SERVER_SPRING}"
     const val GOOGLE_PROTOBUF = "com.google.protobuf:protobuf-java:${DependencyVersion.GOOGLE_PROTOBUF}"
+
+    // Spring Cloud Config
+    const val SPRING_CLOUD_CONFIG = "org.springframework.cloud:spring-cloud-starter-config"
 }

--- a/buildSrc/src/main/kotlin/DependencyVersion.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersion.kt
@@ -14,4 +14,6 @@ object DependencyVersion {
     const val PROTOBUF = "3.25.3"
     const val GRPC_SERVER_SPRING = "2.15.0.RELEASE"
     const val GOOGLE_PROTOBUF = "3.25.3"
+
+    const val SPRING_CLOUD_CONFIG_VERSION = "2023.0.3"
 }

--- a/casper-schedule/build.gradle.kts
+++ b/casper-schedule/build.gradle.kts
@@ -15,6 +15,12 @@ repositories {
 	mavenCentral()
 }
 
+dependencyManagement {
+	imports {
+		mavenBom("org.springframework.cloud:spring-cloud-dependencies:${DependencyVersion.SPRING_CLOUD_CONFIG_VERSION}")
+	}
+}
+
 dependencies {
 	// 스프링 부트 기본 기능
 	implementation(Dependencies.SPRING_BOOT_STARTER)
@@ -66,6 +72,9 @@ dependencies {
 	testImplementation(Dependencies.GRPC_TESTING)
 	implementation(Dependencies.GRPC_SERVER_SPRING)
 	implementation(Dependencies.GOOGLE_PROTOBUF)
+
+	// Cloud Config
+	implementation(Dependencies.SPRING_CLOUD_CONFIG)
 }
 
 

--- a/casper-schedule/src/main/resources/application.yml
+++ b/casper-schedule/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  application:
+    name: Casper-Schedule
+  config:
+    import: "configserver:${CONFIG_SERVER_URL}"
+  cloud:
+    config:
+      label: main
+      fail-fast: true
+      retry:
+        initial-interval: 1000
+        max-attempts: 6
+        max-interval: 2000
+        multiplier: 1.1
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,refresh


### PR DESCRIPTION
- spring cloud config 의존성을 추가하고 다음과 같이 spring cloud config을 설정하였습니다.

`application.yml`
```
spring:
    application:
        name: Casper-Schedule
    config:
        import: "configserver:${CONFIG_SERVER_URL}"
    cloud:
        config:
            label: main
            fail-fast: true
            retry:
                initial-interval: 1000
                max-attempts: 6
                max-interval: 2000
                multiplier: 1.1
    profiles:
        active: ${SPRING_PROFILES_ACTIVE}

management:
    endpoints:
        web:
            exposure:
                include: health,info,refresh

```