### PR TITLE
chore ( #26 ) : application.yml에 spring cloud config 재설정

### DIFF
--- a/casper-schedule/src/main/resources/application.yml
+++ b/casper-schedule/src/main/resources/application.yml
@@ -1,11 +1,11 @@
 spring:
   application:
-    name: Casper-Schedule
+    name: ${SPRING_APPLICATION_NAME}
   config:
-    import: "configserver:${CONFIG_SERVER_URL}"
+    import: "configserver:${SPRING_CLOUD_CONFIG_URL}"
   cloud:
     config:
-      label: main
+      label: ${SPRING_CLOUD_CONFIG_LABEL}
       fail-fast: true
       retry:
         initial-interval: 1000
@@ -13,10 +13,8 @@ spring:
         max-interval: 2000
         multiplier: 1.1
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE}
+    active: ${SPRING_CLOUD_CONFIG_PROFILE}
 
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health,info,refresh
+encrypt:
+  key: ${ENCRYPT_KEY}
+  salt: ${ENCRYPT_SALT}


### PR DESCRIPTION
- application.yml을 다음과 같이 재설정하였습니다.

```application.yml
spring:
  application:
    name: ${SPRING_APPLICATION_NAME}
  config:
    import: "configserver:${SPRING_CLOUD_CONFIG_URL}"
  cloud:
    config:
      label: ${SPRING_CLOUD_CONFIG_LABEL}
      fail-fast: true
      retry:
        initial-interval: 1000
        max-attempts: 6
        max-interval: 2000
        multiplier: 1.1
  profiles:
    active: ${SPRING_CLOUD_CONFIG_PROFILE}

encrypt:
  key: ${ENCRYPT_KEY}
  salt: ${ENCRYPT_SALT}
```